### PR TITLE
Add ARM64 GCC4 build for Linux.yml

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -16,12 +16,15 @@ jobs:
       matrix:
         # Add commits/tags to build against other DuckDB versions
         duckdb_version: [ '<submodule_version>' ]
-        arch: ['linux_amd64', 'linux_arm64', 'linux_amd64_gcc4']
+        arch: ['linux_amd64', 'linux_arm64', 'linux_amd64_gcc4', 'linux_arm64_gcc4']
         vcpkg_version: [ '2023.04.15' ]
         include:
           - arch: 'linux_amd64_gcc4'
             container: 'quay.io/pypa/manylinux2014_x86_64'
             vcpkg_triplet: 'x64-linux'
+          - arch: 'linux_arm64_gcc4'
+            container: 'quay.io/pypa/manylinux2014_aarch64'
+            vcpkg_triplet: 'arm64-linux'  
           - arch: 'linux_amd64'
             container: 'ubuntu:18.04'
             vcpkg_triplet: 'x64-linux'
@@ -66,7 +69,7 @@ jobs:
           git checkout ${{ matrix.duckdb_version }}
 
       - name: Setup ManyLinux2014
-        if: ${{ matrix.arch == 'linux_amd64_gcc4' }}
+        if: ${{ matrix.arch == 'linux_amd64_gcc4' || matrix.arch == 'linux_arm64_gcc4' }}
         run: |
           ./duckdb/scripts/setup_manylinux2014.sh general aws-cli ccache ssh openssl python_alias
 
@@ -86,8 +89,8 @@ jobs:
         env:
           GEN: ninja
           STATIC_LIBCPP: 1
-          CC: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || '' }}
-          CXX: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}
+          CC: ${{ (matrix.arch == 'linux_arm64' || matrix.arch == 'linux_arm64_gcc4') && 'aarch64-linux-gnu-gcc' || '' }}
+          CXX: ${{ (matrix.arch == 'linux_arm64' || matrix.arch == 'linux_arm64_gcc4') && 'aarch64-linux-gnu-g++' || '' }}
         run: |
           make release
 


### PR DESCRIPTION
Trying to launch a DuckDB through Jupyter Lab on an AWS c7g instance.
Running 
```
INSTALL aws;
```

led to try to download `http://extensions.duckdb.org/v0.9.1/linux_arm64_gcc4/aws.duckdb_extension.gz`
However that version doesn't exist.

I tried manually `http://extensions.duckdb.org/v0.9.1/linux_arm64/aws.duckdb_extension.gz` and it crashes my app.

I suspect that we should be building for that arch so I'm adding it to the matrix arch on the Github actions.
