### PR TITLE
add openssl to vcpkg deps

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "dependencies": [
     "zlib",
-    "aws-sdk-cpp"
+    "aws-sdk-cpp",
+    "openssl"
   ]
 }


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb_aws/issues/30

Somehow a dynamically openssl got linked during build. 

Solved by adding openssl to vcpkg dependencies.