### PR TITLE
re-enable minio tests in ci

### DIFF
--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -9,7 +9,6 @@ defaults:
 
 jobs:
   minio-tests:
-    if: false
     name: Minio Tests
     runs-on: ubuntu-20.04
     strategy:
@@ -63,6 +62,8 @@ jobs:
         shell: bash
         run: |
           cd duckdb
+          mkdir data/attach_test
+          touch data/attach_test/attach.db
           sudo ./scripts/install_s3_test_server.sh
           source ./scripts/run_s3_test_server.sh
           sleep 30


### PR DESCRIPTION
Due to some upstream changes, with the attach.db file missing the script would fail. Since we don't currently use it in the minio tests, we can just add an empty file there for now