### PR TITLE
STS needs to be statically linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 # Weirdly we need to manually to this, otherwise linking against
 # ${AWSSDK_LINK_LIBRARIES} fails for some reason
 find_package(ZLIB REQUIRED)
-find_package(AWSSDK REQUIRED COMPONENTS core)
+find_package(AWSSDK REQUIRED COMPONENTS core sts)
 
 # Build static lib
 target_include_directories(${EXTENSION_NAME}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,10 @@
 {
   "dependencies": [
     "zlib",
-    "aws-sdk-cpp",
+    {
+      "name": "aws-sdk-cpp",
+      "features": [ "sts" ]
+    },
     "openssl"
   ],
   "builtin-baseline": "a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6",


### PR DESCRIPTION
This is needed to support loading roles on kubernetes pod using web identity federation, if STS is not there, the aws-sdk credentials chain will ignore this method and fallback to the instance metadata role which would not be the expected role for the application code

https://github.com/duckdb/duckdb_aws/issues/31