### PR TITLE
support AWS SSO authentication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 # Weirdly we need to manually to this, otherwise linking against
 # ${AWSSDK_LINK_LIBRARIES} fails for some reason
 find_package(ZLIB REQUIRED)
-find_package(AWSSDK REQUIRED COMPONENTS core sts)
+find_package(AWSSDK REQUIRED COMPONENTS core sso sts)
 
 # Build static lib
 target_include_directories(${EXTENSION_NAME}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
     "zlib",
     {
       "name": "aws-sdk-cpp",
-      "features": [ "sts" ]
+      "features": [ "sso", "sts" ]
     },
     "openssl"
   ],


### PR DESCRIPTION
The aws extension doesn't correctly work with the `sso` credential provider, [as noted](https://github.com/duckdb/duckdb_aws/issues/31#issuecomment-1956108496) in a comment in #31 (and possibly also #42?  It's unclear in that report which credential provider the user is using).  As noted in PR #45, the `aws-sdk-cpp` library needs to include the `sts` feature for that credential provider to work; similarly, it needs the `sso` feature for this provider to work.

I've confirmed that my change fixes the behaviour (at least for me): 

```
~/src/duckdb_aws > make release
<snip>
~/src/duckdb_aws > aws sso login
<snip>
~/src/duckdb_aws > build/release/duckdb
v1.0.0 1f98600c2c
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D CREATE SECRET(TYPE S3, PROVIDER CREDENTIAL_CHAIN);
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ true    │
└─────────┘
D SELECT * FROM read_parquet('s3://my_bucket/*.parquet');
100% ▕████████████████████████████████████████████████████████████▏
...
```

I tried to look at the other credential providers that duckdb_aws (claims to) provide [in the docs](https://duckdb.org/docs/extensions/httpfs/s3api.html): afaict, `config` and `env` work now.  `sts` was fixed (I believe) by #45, and this PR should fix `sso`.  I "assume" that `process` works correctly, so the only one I'm not sure about is `instance` but this is just hitting the instance metadata store on an EC2 instance so I feel like it "should" work?  The web identity token method described in #16 and #31 maybe just requires some other `aws-sdk-cpp` feature to be enabled, but I'm not really sure which one and don't have a good way to test that in any case.

Hope this is helpful!